### PR TITLE
fix: allow later stripe versions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 .DS_Store
+*~
 *.pyc
 *.egg-info
 *.swp

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
 # frappe -- https://github.com/frappe/frappe is installed via 'bench init'
 paytmchecksum~=1.7.0
 razorpay~=1.2.0
-stripe~=2.56.0
+stripe>=2.56.0,<=5.0.0
 braintree~=4.8.0


### PR DESCRIPTION
Upgrade stripe library requirement.

v5.0.0 tested and working
PR also on frappe version-13-hotfix

Also .gitignore nano file backups