### PR TITLE
change float to integer at final step

### DIFF
--- a/payments/payment_gateways/doctype/razorpay_settings/razorpay_settings.py
+++ b/payments/payment_gateways/doctype/razorpay_settings/razorpay_settings.py
@@ -214,7 +214,7 @@ class RazorpaySettings(Document):
 
 		# Setup payment options
 		payment_options = {
-			"amount": kwargs.get("amount"),
+			"amount": round(kwargs.get("amount")),
 			"currency": kwargs.get("currency", "INR"),
 			"receipt": kwargs.get("receipt"),
 			"payment_capture": kwargs.get("payment_capture"),


### PR DESCRIPTION
issue : In razorpay create order if we send a float value then it is not being converted to int and due to this razorpay is throwing an error 
solution : round off the value to nearest int