### PR TITLE
Added double quotes to stripe_checkout image src

### DIFF
--- a/payments/templates/pages/stripe_checkout.html
+++ b/payments/templates/pages/stripe_checkout.html
@@ -15,7 +15,7 @@
 <div class="stripe" style="min-height: 400px; padding-bottom: 50px; margin-top:100px;margin-left:250px;">
 	<div class="col-sm-10 col-sm-offset-2">
 		{% if image %}
-			<img src={{image}}>
+			<img src="{{image}}">
 		{% endif %}
 		<h2 class="text-center">{{description}}</h2>
 		<form id="payment-form">


### PR DESCRIPTION
The Image displayed on the stripe_checkout.html page is not quoted, so it fails if there are spaces in the image path.  Added double quotes surrounding the {{image}} slot. 