### PR TITLE
fix: update stripe redirect URL to include reference doctype

### DIFF
--- a/payments/payment_gateways/doctype/stripe_settings/stripe_settings.py
+++ b/payments/payment_gateways/doctype/stripe_settings/stripe_settings.py
@@ -255,7 +255,9 @@ class StripeSettings(Document):
 				if custom_redirect_to:
 					redirect_to = custom_redirect_to
 
-				redirect_url = "payment-success"
+				redirect_url = "payment-success?doctype={}&docname={}".format(
+					self.data.reference_doctype, self.data.reference_docname
+				)
 
 			if self.redirect_url:
 				redirect_url = self.redirect_url


### PR DESCRIPTION
![image](https://github.com/frappe/payments/assets/5266522/c71e1aa8-2b28-4b44-bc39-6d6c9141cca5)

The pull request proposes to fix a specific issue related to the Stripe payment integration by updating the URL used for redirection. The key improvement is to modify this URL so that it includes a reference to a particular document type.