### PR TITLE
fix(payments): separate redirect constructor from authorization hook

### DIFF
--- a/payments/payment_gateways/doctype/braintree_settings/braintree_settings.py
+++ b/payments/payment_gateways/doctype/braintree_settings/braintree_settings.py
@@ -250,9 +250,12 @@ class BraintreeSettings(Document):
 			if self.data.reference_doctype and self.data.reference_docname:
 				custom_redirect_to = None
 				try:
+					frappe.get_doc(self.data.reference_doctype, self.data.reference_docname).run_method(
+						"on_payment_authorized", self.flags.status_changed_to
+					)
 					custom_redirect_to = frappe.get_doc(
 						self.data.reference_doctype, self.data.reference_docname
-					).run_method("on_payment_authorized", self.flags.status_changed_to)
+					).run_method("on_payment_authorized_redirect", self.flags.status_changed_to)
 					braintree_success_page = frappe.get_hooks("braintree_success_page")
 					if braintree_success_page:
 						custom_redirect_to = frappe.get_attr(braintree_success_page[-1])(self.data)

--- a/payments/payment_gateways/doctype/gocardless_settings/gocardless_settings.py
+++ b/payments/payment_gateways/doctype/gocardless_settings/gocardless_settings.py
@@ -180,9 +180,12 @@ class GoCardlessSettings(Document):
 			if "reference_doctype" in self.data and "reference_docname" in self.data:
 				custom_redirect_to = None
 				try:
-					custom_redirect_to = frappe.get_doc(
+					frappe.get_doc(
 						self.data.get("reference_doctype"), self.data.get("reference_docname")
 					).run_method("on_payment_authorized", self.flags.status_changed_to)
+					custom_redirect_to = frappe.get_doc(
+						self.data.get("reference_doctype"), self.data.get("reference_docname")
+					).run_method("on_payment_authorized_redirect", self.flags.status_changed_to)
 				except Exception:
 					frappe.log_error("Gocardless redirect failed")
 

--- a/payments/payment_gateways/doctype/paypal_settings/paypal_settings.py
+++ b/payments/payment_gateways/doctype/paypal_settings/paypal_settings.py
@@ -330,10 +330,15 @@ def confirm_payment(token):
 			)
 
 			if data.get("reference_doctype") and data.get("reference_docname"):
+				frappe.get_doc(data.get("reference_doctype"), data.get("reference_docname")).run_method(
+					"on_payment_authorized", "Completed"
+				)
+
+				frappe.db.commit()
+
 				custom_redirect_to = frappe.get_doc(
 					data.get("reference_doctype"), data.get("reference_docname")
-				).run_method("on_payment_authorized", "Completed")
-				frappe.db.commit()
+				).run_method("on_payment_authorized_redirect", "Completed")
 
 			redirect_url = "payment-success?doctype={}&docname={}".format(
 				data.get("reference_doctype"), data.get("reference_docname")
@@ -399,10 +404,16 @@ def create_recurring_profile(token, payerid):
 				data["subscription_id"] = response.get("PROFILEID")[0]
 
 				frappe.flags.data = data
+
+				frappe.get_doc(data.get("reference_doctype"), data.get("reference_docname")).run_method(
+					"on_payment_authorized", status_changed_to
+				)
+
+				frappe.db.commit()
+
 				custom_redirect_to = frappe.get_doc(
 					data.get("reference_doctype"), data.get("reference_docname")
-				).run_method("on_payment_authorized", status_changed_to)
-				frappe.db.commit()
+				).run_method("on_payment_authorized_redirect", status_changed_to)
 
 			redirect_url = "payment-success?doctype={}&docname={}".format(
 				data.get("reference_doctype"), data.get("reference_docname")

--- a/payments/payment_gateways/doctype/paytm_settings/paytm_settings.py
+++ b/payments/payment_gateways/doctype/paytm_settings/paytm_settings.py
@@ -156,9 +156,13 @@ def finalize_request(order_id, transaction_response):
 		if transaction_data.reference_doctype and transaction_data.reference_docname:
 			custom_redirect_to = None
 			try:
-				custom_redirect_to = frappe.get_doc(
+				frappe.get_doc(
 					transaction_data.reference_doctype, transaction_data.reference_docname
 				).run_method("on_payment_authorized", "Completed")
+
+				custom_redirect_to = frappe.get_doc(
+					transaction_data.reference_doctype, transaction_data.reference_docname
+				).run_method("on_payment_authorized_redirect", "Completed")
 				request.db_set("status", "Completed")
 			except Exception:
 				request.db_set("status", "Failed")

--- a/payments/payment_gateways/doctype/razorpay_settings/razorpay_settings.py
+++ b/payments/payment_gateways/doctype/razorpay_settings/razorpay_settings.py
@@ -296,9 +296,12 @@ class RazorpaySettings(Document):
 				custom_redirect_to = None
 				try:
 					frappe.flags.data = data
+					frappe.get_doc(self.data.reference_doctype, self.data.reference_docname).run_method(
+						"on_payment_authorized", self.flags.status_changed_to
+					)
 					custom_redirect_to = frappe.get_doc(
 						self.data.reference_doctype, self.data.reference_docname
-					).run_method("on_payment_authorized", self.flags.status_changed_to)
+					).run_method("on_payment_authorized_redirect", self.flags.status_changed_to)
 
 				except Exception:
 					frappe.log_error(frappe.get_traceback())

--- a/payments/payment_gateways/doctype/stripe_settings/stripe_settings.py
+++ b/payments/payment_gateways/doctype/stripe_settings/stripe_settings.py
@@ -246,9 +246,13 @@ class StripeSettings(Document):
 			if self.data.reference_doctype and self.data.reference_docname:
 				custom_redirect_to = None
 				try:
+					frappe.get_doc(self.data.reference_doctype, self.data.reference_docname).run_method(
+						"on_payment_authorized", self.flags.status_changed_to
+					)
+
 					custom_redirect_to = frappe.get_doc(
 						self.data.reference_doctype, self.data.reference_docname
-					).run_method("on_payment_authorized", self.flags.status_changed_to)
+					).run_method("on_payment_authorized_redirect", self.flags.status_changed_to)
 				except Exception:
 					frappe.log_error(frappe.get_traceback())
 


### PR DESCRIPTION
Reincarnation of frappe/erpnext#37502 for the same reasons

Sister PR: https://github.com/frappe/webshop/pull/36


This is a prerequisite for PayZen IPN implementation, potentially current IPN implementations harbor a slient bug.