### PR TITLE
fix: typo in GoCardless Settings name

### DIFF
--- a/payments/payment_gateways/doctype/gocardless_settings/gocardless_settings.py
+++ b/payments/payment_gateways/doctype/gocardless_settings/gocardless_settings.py
@@ -32,7 +32,7 @@ class GoCardlessSettings(Document):
 		from payments.utils import create_payment_gateway
 
 		create_payment_gateway(
-			"GoCardless-" + self.gateway_name, settings="GoCardLess Settings", controller=self.gateway_name
+			"GoCardless-" + self.gateway_name, settings="GoCardless Settings", controller=self.gateway_name
 		)
 		call_hook_method("payment_gateway_enabled", gateway="GoCardless-" + self.gateway_name)
 


### PR DESCRIPTION
should be a lower-case l instead of an uppercase L