### PR TITLE
feat: set ERPNext Payment Request status from GoCardless Webhook

### DIFF
--- a/payments/payment_gateways/doctype/gocardless_settings/__init__.py
+++ b/payments/payment_gateways/doctype/gocardless_settings/__init__.py
@@ -67,6 +67,10 @@ def set_payment_request_status(event):
 		doc.set_as_cancelled()
 	if event_action == "failed" and doc.status != "Failed":
 		doc.db_set("status", "Failed")
+		try: # failed reason is a field in ERPNext version 16+, so it may not exist in the database
+			doc.db_set("failed_reason", event["details"]["description"])
+		except:
+			pass
 
 
 def authenticate_signature(r):

--- a/payments/payment_gateways/doctype/gocardless_settings/gocardless_settings.py
+++ b/payments/payment_gateways/doctype/gocardless_settings/gocardless_settings.py
@@ -147,6 +147,8 @@ class GoCardlessSettings(Document):
 				},
 			)
 
+			self.integration_request.db_set("output", payment.api_response._response._content.decode())
+
 			match payment.status:
 				case "pending_submission" | "pending_customer_approval" | "submitted":
 					self.integration_request.db_set("status", "Authorized", update_modified=False)
@@ -169,7 +171,8 @@ class GoCardlessSettings(Document):
 					self.integration_request.db_set("error", payment.status, update_modified=False)
 
 		except Exception as e:
-			frappe.log_error("GoCardless Payment Error", e)
+			self.integration_request.db_set("error", str(e))
+			frappe.log_error("GoCardless Payment Error", str(e))
 
 		if self.flags.status_changed_to == "Completed":
 			status = "Completed"


### PR DESCRIPTION
This enables updating a related ERPNext Payment Request from a GoCardless Webhook with type of "payments".

The previous code only updated Payments Mandates from a GoCardless Webhook with type "mandates".