### PR TITLE
fix: header_img field schema (backport #83)

### DIFF
--- a/payments/payment_gateways/doctype/gocardless_settings/gocardless_settings.json
+++ b/payments/payment_gateways/doctype/gocardless_settings/gocardless_settings.json
@@ -10,7 +10,8 @@
   "section_break_2",
   "access_token",
   "webhooks_secret",
-  "use_sandbox"
+  "use_sandbox",
+  "header_img"
  ],
  "fields": [
   {
@@ -42,10 +43,15 @@
    "fieldname": "use_sandbox",
    "fieldtype": "Check",
    "label": "Use Sandbox"
+  },
+  {
+   "fieldname": "header_img",
+   "fieldtype": "Attach Image",
+   "label": "Header Image"
   }
  ],
  "links": [],
- "modified": "2023-09-22 13:33:42.225243",
+ "modified": "2024-07-19 14:25:31.848494",
  "modified_by": "Administrator",
  "module": "Payment Gateways",
  "name": "GoCardless Settings",


### PR DESCRIPTION
Backport #83 to version-15, updating the schema of gocardless_settings.json to include the header_img field so GoCardless can be functional. Thank you!