### PR TITLE
fix: get parameters on both success and failed page

### DIFF
--- a/payments/payment_gateways/doctype/braintree_settings/braintree_settings.py
+++ b/payments/payment_gateways/doctype/braintree_settings/braintree_settings.py
@@ -267,10 +267,12 @@ class BraintreeSettings(Document):
 			)
 		else:
 			status = "Error"
-			redirect_url = "payment-failed"
+			redirect_url = (
+				f"payment-failed?doctype={self.data.reference_doctype}&docname={self.data.reference_docname}"
+			)
 
 		if redirect_to:
-			redirect_url += "?" + urlencode({"redirect_to": redirect_to})
+			redirect_url += "&" + urlencode({"redirect_to": redirect_to})
 		if redirect_message:
 			redirect_url += "&" + urlencode({"redirect_message": redirect_message})
 


### PR DESCRIPTION
continues: https://github.com/frappe/payments/pull/122