### PR TITLE
fix: make Stripe checkout page responsive

### DIFF
--- a/payments/templates/pages/stripe_checkout.css
+++ b/payments/templates/pages/stripe_checkout.css
@@ -99,3 +99,19 @@
 .field:-ms-input-placeholder {
   color: #CFD7E0;
 }
+
+#payment-section {
+  min-height: 50vh;
+  display: flex;
+  justify-content: center;
+  align-items: center;
+  flex-direction: column;
+  padding: 10rem;
+}
+
+@media (max-width: 48rem) {
+  #payment-section {
+    padding: 0rem;
+    min-height: 70vh;
+  },
+}

--- a/payments/templates/pages/stripe_checkout.html
+++ b/payments/templates/pages/stripe_checkout.html
@@ -12,7 +12,7 @@
 
 {%- block page_content -%}
 
-<div class="stripe" style="min-height: 400px; padding-bottom: 50px; margin-top:100px;margin-left:250px;">
+<div class="stripe" id="payment-section">
 	<div class="col-sm-10 col-sm-offset-2">
 		{% if image %}
 			<img src={{image}}>


### PR DESCRIPTION
Issue: Stripe Checkout page is not responsive.

Ref: [#41402](https://support.frappe.io/helpdesk/tickets/41402)

Before:

<img width="383" alt="Screenshot 2025-06-19 at 1 21 31 PM" src="https://github.com/user-attachments/assets/ecfcca50-7a8f-4951-8abf-5ecaf8e2c9a4" />

After:

<img width="383" alt="Screenshot 2025-06-19 at 1 21 06 PM" src="https://github.com/user-attachments/assets/45e9a4a1-cfa1-4982-9a2c-65be014261d8" />

resolves [#151](https://github.com/frappe/payments/issues/151)

Backport Needed: v15