### PR TITLE
fix: Create Razorpay Order before Creating Razorpay Payment URL

### DIFF
--- a/payments/hooks.py
+++ b/payments/hooks.py
@@ -112,6 +112,9 @@ override_doctype_class = {"Web Form": "payments.overrides.payment_webform.Paymen
 # ---------------
 
 scheduler_events = {
+	"hourly": [
+        "payments.payment_gateways.doctype.razorpay_settings.razorpay_settings.verify_pending_payments",
+	],
 	"all": [
 		"payments.payment_gateways.doctype.razorpay_settings.razorpay_settings.capture_payment",
 	],

--- a/payments/payment_gateways/doctype/razorpay_settings/razorpay_settings.py
+++ b/payments/payment_gateways/doctype/razorpay_settings/razorpay_settings.py
@@ -553,6 +553,47 @@ def capture_payment(is_sandbox=False, sanbox_response=None):
 			doc.save()
 			frappe.log_error(doc.error, f"{doc.name} Failed")
 
+def verify_pending_payments(is_sandbox=False, sanbox_response=None):
+	"""
+	Checks for the pending payments being authorised at Razorpay End but in Frappe
+	After Successful Payment, the razorpay_checkout.js handles the Razorpay response
+	If User closes the browser before the payment is completed, then payment is not authorised in Frappe
+
+	"""
+	controller = frappe.get_doc("Razorpay Settings")
+	for doc in frappe.get_all(
+		"Integration Request",
+		filters={"status": "Queued", "integration_request_service": "Razorpay"}
+	):
+		try:
+			if is_sandbox:
+				resp = sanbox_response
+			else:
+				doc = frappe.get_doc("Integration Request", doc.name)
+				data = json.loads(doc.data)
+				settings = controller.get_settings(data)
+				resp = make_get_request(
+					"https://api.razorpay.com/v1/orders/{0}/payments".format(data.get("order_id")),
+					auth=(settings.api_key, settings.api_secret),
+				)
+				if resp:
+					resp.update({"razorpay_payment_id": resp.get("id")})
+					if resp.get("status") == "authorized":
+						doc.update_status(resp, 'Authorized')
+						status_changed_to = "Authorized"
+					
+					if resp.get("status") == "captured":
+						doc.update_status(resp, 'Completed')
+						status_changed_to = "Completed"
+					
+					if status_changed_to in ("Authorized", "Verified", "Completed"):
+						if doc.reference_doctype and doc.reference_docname:
+							frappe.get_doc(
+								doc.reference_doctype, doc.reference_docname
+								).run_method("on_payment_authorized", status_changed_to)
+		except Exception:
+			frappe.log_error(frappe.get_traceback(), f"{doc.name} Failed")
+
 
 @frappe.whitelist(allow_guest=True)
 def get_api_key():

--- a/payments/payment_gateways/doctype/razorpay_settings/razorpay_settings.py
+++ b/payments/payment_gateways/doctype/razorpay_settings/razorpay_settings.py
@@ -73,7 +73,7 @@ from frappe.integrations.utils import (
 	make_post_request,
 )
 from frappe.model.document import Document
-from frappe.utils import call_hook_method, cint, get_timestamp, get_url
+from frappe.utils import call_hook_method, cint, get_timestamp, get_url, flt
 
 from payments.utils import create_payment_gateway
 
@@ -334,7 +334,7 @@ class RazorpaySettings(Document):
 		# Creating Orders https://razorpay.com/docs/api/orders/
 
 		# convert rupees to paisa
-		kwargs["amount"] *= 100
+		kwargs["amount"] = int(kwargs.get('amount')) * 100
 
 		# Create integration log
 		if create_integration_request:
@@ -342,7 +342,7 @@ class RazorpaySettings(Document):
 
 		# Setup payment options
 		payment_options = {
-			"amount": kwargs.get("amount"),
+			"amount": flt(kwargs.get('amount'), precision=0),
 			"currency": kwargs.get("currency", "INR"),
 			"receipt": kwargs.get("receipt"),
 			"payment_capture": kwargs.get("payment_capture"),

--- a/payments/payment_gateways/doctype/razorpay_settings/razorpay_settings.py
+++ b/payments/payment_gateways/doctype/razorpay_settings/razorpay_settings.py
@@ -325,17 +325,20 @@ class RazorpaySettings(Document):
 		return kwargs
 
 	def get_payment_url(self, **kwargs):
+		order = self.create_order(create_integration_request=False, **kwargs)
+		kwargs["order_id"] = order["id"]
 		integration_request = create_request_log(kwargs, service_name="Razorpay")
 		return get_url(f"./razorpay_checkout?token={integration_request.name}")
 
-	def create_order(self, **kwargs):
+	def create_order(self, create_integration_request=True, **kwargs):
 		# Creating Orders https://razorpay.com/docs/api/orders/
 
 		# convert rupees to paisa
 		kwargs["amount"] = int(kwargs["amount"] * 100)
 
 		# Create integration log
-		integration_request = create_request_log(kwargs, service_name="Razorpay")
+		if create_integration_request:
+			integration_request = create_request_log(kwargs, service_name="Razorpay")
 
 		# Setup payment options
 		payment_options = {
@@ -353,8 +356,10 @@ class RazorpaySettings(Document):
 						self.get_password(fieldname="api_secret", raise_exception=False),
 					),
 					data=payment_options,
+					headers={"content-type": "application/json"},
 				)
-				order["integration_request"] = integration_request.name
+				if create_integration_request:
+					order["integration_request"] = integration_request.name
 				return order  # Order returned to be consumed by razorpay.js
 			except Exception:
 				frappe.log(frappe.get_traceback())

--- a/payments/payment_gateways/doctype/razorpay_settings/razorpay_settings.py
+++ b/payments/payment_gateways/doctype/razorpay_settings/razorpay_settings.py
@@ -577,6 +577,7 @@ def verify_pending_payments(is_sandbox=False, sanbox_response=None):
 					auth=(settings.api_key, settings.api_secret),
 				)
 				if resp:
+					status_changed_to = ""
 					resp.update({"razorpay_payment_id": resp.get("id")})
 					if resp.get("status") == "authorized":
 						doc.update_status(resp, 'Authorized')
@@ -586,7 +587,7 @@ def verify_pending_payments(is_sandbox=False, sanbox_response=None):
 						doc.update_status(resp, 'Completed')
 						status_changed_to = "Completed"
 					
-					if status_changed_to in ("Authorized", "Verified", "Completed"):
+					if status_changed_to in ("Authorized", "Completed"):
 						if doc.reference_doctype and doc.reference_docname:
 							frappe.get_doc(
 								doc.reference_doctype, doc.reference_docname

--- a/payments/payment_gateways/doctype/razorpay_settings/razorpay_settings.py
+++ b/payments/payment_gateways/doctype/razorpay_settings/razorpay_settings.py
@@ -334,7 +334,7 @@ class RazorpaySettings(Document):
 		# Creating Orders https://razorpay.com/docs/api/orders/
 
 		# convert rupees to paisa
-		kwargs["amount"] = int(kwargs["amount"] * 100)
+		kwargs["amount"] *= 100
 
 		# Create integration log
 		if create_integration_request:
@@ -355,7 +355,7 @@ class RazorpaySettings(Document):
 						self.api_key,
 						self.get_password(fieldname="api_secret", raise_exception=False),
 					),
-					data=payment_options,
+					data=json.dumps(payment_options),
 					headers={"content-type": "application/json"},
 				)
 				if create_integration_request:

--- a/payments/payment_gateways/doctype/razorpay_settings/razorpay_settings.py
+++ b/payments/payment_gateways/doctype/razorpay_settings/razorpay_settings.py
@@ -572,16 +572,16 @@ def verify_pending_payments(is_sandbox=False, sanbox_response=None):
 				doc = frappe.get_doc("Integration Request", doc.name)
 				data = json.loads(doc.data)
 				settings = controller.get_settings(data)
-				resp = check_razorpay_payment_status(data.get("order_id"), settings)
-				if resp:
+				payment_details = check_razorpay_payment_status(data.get("order_id"), settings)
+				if payment_details:
 					status_changed_to = ""
-					resp.update({"razorpay_payment_id": resp.get("id")})
-					if resp.get("status") == "authorized":
-						doc.update_status(resp, 'Authorized')
+					payment_details.update({"razorpay_payment_id": payment_details.get("id")})
+					if payment_details.get("status") == "authorized":
+						doc.update_status(payment_details, 'Authorized')
 						status_changed_to = "Authorized"
 					
-					if resp.get("status") == "captured":
-						doc.update_status(resp, 'Completed')
+					if payment_details.get("status") == "captured":
+						doc.update_status(payment_details, 'Completed')
 						status_changed_to = "Completed"
 					
 					if status_changed_to in ("Authorized", "Completed"):
@@ -595,11 +595,11 @@ def verify_pending_payments(is_sandbox=False, sanbox_response=None):
 def check_razorpay_payment_status(order_id, settings):
 	try:
 
-		resp = make_get_request("https://api.razorpay.com/v1/orders/{0}/payments"
-			.format(order_id), auth=(settings.api_key,
-				settings.get_password(fieldname="api_secret", raise_exception=False)))
-
-		if len(resp.get("items")) != 0:
+		resp = make_get_request(
+			"https://api.razorpay.com/v1/orders/{0}/payments".format(order_id),
+			auth=(settings.api_key, settings.api_secret),
+		)
+		if len(resp.get("items")):
 			for i in resp.get("items"):
 				if i.get("status") in ("authorized", "captured"):
 					return i

--- a/payments/payment_gateways/doctype/razorpay_settings/razorpay_settings.py
+++ b/payments/payment_gateways/doctype/razorpay_settings/razorpay_settings.py
@@ -572,10 +572,7 @@ def verify_pending_payments(is_sandbox=False, sanbox_response=None):
 				doc = frappe.get_doc("Integration Request", doc.name)
 				data = json.loads(doc.data)
 				settings = controller.get_settings(data)
-				resp = make_get_request(
-					"https://api.razorpay.com/v1/orders/{0}/payments".format(data.get("order_id")),
-					auth=(settings.api_key, settings.api_secret),
-				)
+				resp = check_razorpay_payment_status(data.get("order_id"), settings)
 				if resp:
 					status_changed_to = ""
 					resp.update({"razorpay_payment_id": resp.get("id")})
@@ -595,6 +592,19 @@ def verify_pending_payments(is_sandbox=False, sanbox_response=None):
 		except Exception:
 			frappe.log_error(frappe.get_traceback(), f"{doc.name} Failed")
 
+def check_razorpay_payment_status(order_id, settings):
+	try:
+
+		resp = make_get_request("https://api.razorpay.com/v1/orders/{0}/payments"
+			.format(order_id), auth=(settings.api_key,
+				settings.get_password(fieldname="api_secret", raise_exception=False)))
+
+		if len(resp.get("items")) != 0:
+			for i in resp.get("items"):
+				if i.get("status") in ("authorized", "captured"):
+					return i
+	except Exception:
+		frappe.log_error(frappe.get_traceback())
 
 @frappe.whitelist(allow_guest=True)
 def get_api_key():

--- a/payments/templates/includes/razorpay_checkout.js
+++ b/payments/templates/includes/razorpay_checkout.js
@@ -6,6 +6,7 @@ $(document).ready(function(){
 			"currency": "{{ currency }}",
 			"name": "{{ title }}",
 			"description": "{{ description }}",
+			"order_id": "{{ order_id }}",
 			"subscription_id": "{{ subscription_id }}",
 			"handler": function (response){
 				razorpay.make_payment_log(response, options, "{{ reference_doctype }}", "{{ reference_docname }}", "{{ token }}");


### PR DESCRIPTION
As per [Razorpay Docs](https://razorpay.com/docs/payments/payment-gateway/web-integration/custom/build-integration/), a Order should be created for every payment, however presently whenever a Payment URL is generated, it skips the Order Creation method which as per Razorpay isn't a good practise.

Further, when a user successfully makes a payment and doesn't wait for re-direction from payment to complete, though the payment is completed, but the same isn't captured in the App.

This PR shall fix these issues.