### PR TITLE
fix: flaky mpesa tests

### DIFF
--- a/payments/payment_gateways/doctype/mpesa_settings/mpesa_settings.py
+++ b/payments/payment_gateways/doctype/mpesa_settings/mpesa_settings.py
@@ -44,8 +44,8 @@ class MpesaSettings(Document):
 		)
 
 		# required to fetch the bank account details from the payment gateway account
-		frappe.db.commit()  # nosemgrep
 		create_mode_of_payment("Mpesa-" + self.payment_gateway_name, payment_type="Phone")
+		frappe.db.commit()  # nosemgrep
 
 	def request_for_payment(self, **kwargs):
 		args = frappe._dict(kwargs)

--- a/payments/payment_gateways/doctype/mpesa_settings/test_mpesa_settings.py
+++ b/payments/payment_gateways/doctype/mpesa_settings/test_mpesa_settings.py
@@ -39,10 +39,12 @@ class TestMpesaSettings(unittest.TestCase):
 			write_off_account="Write Off - WP",
 			write_off_cost_center="Main - WP",
 		)
-		self.pos_profile = pos_profile.name
-		create_opening_entry(pos_profile, frappe.session.user)
+		self.pos_profile = pos_profile
 
 	def tearDown(self):
+		frappe.db.rollback()
+		for x in frappe.db.get_all("POS Opening Entry"):
+			frappe.get_doc("POS Opening Entry", x.name).cancel().delete()
 		frappe.db.sql("delete from `tabMpesa Settings`")
 		frappe.db.sql("delete from `tabIntegration Request` where integration_request_service = 'Mpesa'")
 
@@ -83,6 +85,7 @@ class TestMpesaSettings(unittest.TestCase):
 		integration_request.delete()
 
 	def test_processing_of_callback_payload(self):
+		create_opening_entry(self.pos_profile, frappe.session.user)
 		frappe.db.set_single_value("POS Settings", "invoice_type", "POS Invoice")
 		mpesa_account = frappe.db.get_value(
 			"Payment Gateway Account", {"payment_gateway": "Mpesa-Payment"}, "payment_account"
@@ -97,7 +100,7 @@ class TestMpesaSettings(unittest.TestCase):
 			cost_center="Main - WP",
 			company="Wind Power LLC",
 			income_account="Sales - WP",
-			pos_profile=self.pos_profile,
+			pos_profile=self.pos_profile.name,
 			account_for_change_amount="Cash - WP",
 			expense_account="Cost of Goods Sold - WP",
 			do_not_submit=1,
@@ -145,6 +148,7 @@ class TestMpesaSettings(unittest.TestCase):
 		pos_invoice.delete()
 
 	def test_processing_of_multiple_callback_payload(self):
+		create_opening_entry(self.pos_profile, frappe.session.user)
 		frappe.db.set_single_value("POS Settings", "invoice_type", "POS Invoice")
 		mpesa_account = frappe.db.get_value(
 			"Payment Gateway Account", {"payment_gateway": "Mpesa-Payment"}, "payment_account"
@@ -161,7 +165,7 @@ class TestMpesaSettings(unittest.TestCase):
 			cost_center="Main - WP",
 			company="Wind Power LLC",
 			income_account="Sales - WP",
-			pos_profile=self.pos_profile,
+			pos_profile=self.pos_profile.name,
 			account_for_change_amount="Cash - WP",
 			expense_account="Cost of Goods Sold - WP",
 			do_not_submit=1,
@@ -215,7 +219,8 @@ class TestMpesaSettings(unittest.TestCase):
 		pr.delete()
 		pos_invoice.delete()
 
-	def test_processing_of_only_one_succes_callback_payload(self):
+	def test_processing_of_only_one_success_callback_payload(self):
+		create_opening_entry(self.pos_profile, frappe.session.user)
 		frappe.db.set_single_value("POS Settings", "invoice_type", "POS Invoice")
 		mpesa_account = frappe.db.get_value(
 			"Payment Gateway Account", {"payment_gateway": "Mpesa-Payment"}, "payment_account"
@@ -232,7 +237,7 @@ class TestMpesaSettings(unittest.TestCase):
 			cost_center="Main - WP",
 			company="Wind Power LLC",
 			income_account="Sales - WP",
-			pos_profile=self.pos_profile,
+			pos_profile=self.pos_profile.name,
 			account_for_change_amount="Cash - WP",
 			expense_account="Cost of Goods Sold - WP",
 			do_not_submit=1,


### PR DESCRIPTION
``` bash
payments.payment_gateways.doctype.mpesa_settings.test_mpesa_settings.TestMpesaSettings
    ✔  test_creation_of_payment_gateway
    ✖  test_processing_of_account_balance
    ✖  test_processing_of_callback_payload
    ✖  test_processing_of_multiple_callback_payload
    ✖  test_processing_of_only_one_succes_callback_payload


======================================================================
 ERROR  test_processing_of_account_balance (payments.payment_gateways.doctype.mpesa_settings.test_mpesa_settings.TestMpesaSettings)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/home/runner/frappe-bench/apps/payments/payments/payment_gateways/doctype/mpesa_settings/test_mpesa_settings.py", line 43, in setUp
    create_opening_entry(pos_profile, frappe.session.user)
    pos_profile = <POSProfile: doctype=POS Profile _Test POS Profile>
    self = <payments.payment_gateways.doctype.mpesa_settings.test_mpesa_settings.TestMpesaSettings testMethod=test_processing_of_account_balance>
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/accounts/doctype/pos_opening_entry/test_pos_opening_entry.py", line 118, in create_opening_entry
    entry.submit()
    balance_details = [{'mode_of_payment': 'Cash', 'doctype': 'POS Opening Entry Detail'}]
    d = <POSPaymentMethod: doctype=POS Payment Method fvkkgi5s8f parent=_Test POS Profile>
    entry = <POSOpeningEntry: doctype=POS Opening Entry POS-OPE-2025-00002 docstatus=1>
    get_obj = False
    pos_profile = <POSProfile: doctype=POS Profile _Test POS Profile>
    user = 'Administrator'
  File "/home/runner/frappe-bench/apps/frappe/frappe/utils/typing_validations.py", line 36, in wrapper
    return func(*args, **kwargs)
    apply_condition = <function _in_request_or_test at 0x7fcb8ea1d630>
    args = (<POSOpeningEntry: doctype=POS Opening Entry POS-OPE-2025-00002 docstatus=1>,)
    func = <function Document.submit at 0x7fcb8d858820>
    kwargs = {}
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1218, in submit
    return self._submit()
    self = <POSOpeningEntry: doctype=POS Opening Entry POS-OPE-2025-00002 docstatus=1>
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1199, in _submit
    return self.save()
    self = <POSOpeningEntry: doctype=POS Opening Entry POS-OPE-2025-00002 docstatus=1>
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 485, in save
    return self._save(*args, **kwargs)
    args = ()
    kwargs = {}
    self = <POSOpeningEntry: doctype=POS Opening Entry POS-OPE-2025-00002 docstatus=1>
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 507, in _save
    return self.insert()
    ignore_permissions = None
    ignore_version = None
    self = <POSOpeningEntry: doctype=POS Opening Entry POS-OPE-2025-00002 docstatus=1>
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 415, in insert
    self.run_before_save_methods()
    ignore_if_duplicate = False
    ignore_links = None
    ignore_mandatory = None
    ignore_permissions = None
    self = <POSOpeningEntry: doctype=POS Opening Entry POS-OPE-2025-00002 docstatus=1>
    set_child_names = True
    set_name = None
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1283, in run_before_save_methods
    self.run_method("validate")
    self = <POSOpeningEntry: doctype=POS Opening Entry POS-OPE-2025-00002 docstatus=1>
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1129, in run_method
    out = Document.hook(fn)(self, *args, **kwargs)
    args = ()
    fn = <function Document.run_method.<locals>.fn at 0x7fcb81fafe20>
    kwargs = {}
    method = 'validate'
    self = <POSOpeningEntry: doctype=POS Opening Entry POS-OPE-2025-00002 docstatus=1>
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1526, in composer
    return composed(self, method, *args, **kwargs)
    args = ()
    compose = <function Document.hook.<locals>.compose at 0x7fcb81faf6d0>
    composed = <function Document.hook.<locals>.compose.<locals>.runner at 0x7fcb81fafac0>
    doc_events = {'*': {'on_update': ['frappe.desk.notifications.clear_doctype_notifications', 'frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions', 'frappe.core.doctype.file.utils.attach_files_to_document', 'frappe.automation.doctype.assignment_rule.assignment_rule.apply', 'frappe.automation.doctype.assignment_rule.assignment_rule.update_due_date', 'frappe.core.doctype.user_type.user_type.apply_permissions_for_non_standard_user_type', 'frappe.core.doctype.permission_log.permission_log.make_perm_log', 'frappe.search.sqlite_search.update_doc_index'], 'after_rename': ['frappe.desk.notifications.clear_doctype_notifications'], 'on_cancel': ['frappe.desk.notifications.clear_doctype_notifications', 'frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions', 'frappe.automation.doctype.assignment_rule.assignment_rule.apply'], 'on_trash': ['frappe.desk.notifications.clear_doctype_notifications', 'frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions', 'frappe.search.sqlite_search.delete_doc_index'], 'on_update_after_submit': ['frappe.workflow.doctype.workflow_action.workflow_action.process_workflow_actions', 'frappe.automation.doctype.assignment_rule.assignment_rule.apply', 'frappe.automation.doctype.assignment_rule.assignment_rule.update_due_date', 'frappe.core.doctype.file.utils.attach_files_to_document'], 'on_change': ['frappe.automation.doctype.milestone_tracker.milestone_tracker.evaluate_milestone'], 'after_delete': ['frappe.core.doctype.permission_log.permission_log.make_perm_log'], 'validate': ['erpnext.support.doctype.service_level_agreement.service_level_agreement.apply', 'erpnext.setup.doctype.transaction_deletion_record.transaction_deletion_record.check_for_running_deletion_job']}, 'Event': {'after_insert': ['frappe.integrations.doctype.google_calendar.google_calendar.insert_event_in_google_calendar', 'erpnext.crm.utils.link_events_with_prospect'], 'on_update': ['frappe.integrations.doctype.google_calendar.google_calendar.update_event_in_google_calendar'], 'on_trash': ['frappe.integrations.doctype.google_calendar.google_calendar.delete_event_from_google_calendar']}, 'Contact': {'after_insert': ['frappe.integrations.doctype.google_contacts.google_contacts.insert_contacts_to_google_contacts', 'erpnext.telephony.doctype.call_log.call_log.link_existing_conversations'], 'on_update': ['frappe.integrations.doctype.google_contacts.google_contacts.update_contacts_to_google_contacts'], 'on_trash': ['erpnext.support.doctype.issue.issue.update_issue'], 'validate': ['erpnext.crm.utils.update_lead_phone_numbers']}, 'DocType': {'on_update': ['frappe.cache_manager.build_domain_restricted_doctype_cache']}, 'Page': {'on_update': ['frappe.cache_manager.build_domain_restricted_page_cache']}, 'Sales Invoice': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save'], 'on_submit': ['erpnext.regional.create_transaction_log', 'erpnext.regional.italy.utils.sales_invoice_on_submit'], 'on_cancel': ['erpnext.regional.italy.utils.sales_invoice_on_cancel'], 'on_trash': ['erpnext.regional.check_deletion_permission']}, 'Purchase Invoice': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save', 'erpnext.regional.united_arab_emirates.utils.update_grand_total_for_rcm', 'erpnext.regional.united_arab_emirates.utils.validate_returns']}, 'Journal Entry': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Bank Clearance': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Stock Entry': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save'], 'on_submit': ['erpnext.stock.doctype.material_request.material_request.update_completed_and_requested_qty'], 'on_cancel': ['erpnext.stock.doctype.material_request.material_request.update_completed_and_requested_qty']}, 'Dunning': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Invoice Discounting': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Payment Entry': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save'], 'on_submit': ['erpnext.regional.create_transaction_log', 'erpnext.accounts.doctype.dunning.dunning.resolve_dunning'], 'on_cancel': ['erpnext.accounts.doctype.dunning.dunning.resolve_dunning'], 'on_trash': ['erpnext.regional.check_deletion_permission']}, 'Period Closing Voucher': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Process Deferred Accounting': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Asset': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Asset Capitalization': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Asset Repair': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Delivery Note': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Landed Cost Voucher': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Purchase Receipt': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Stock Reconciliation': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'Subcontracting Receipt': {'validate': ['erpnext.accounts.doctype.accounting_period.accounting_period.validate_accounting_period_on_doc_save']}, 'User': {'after_insert': ['frappe.contacts.doctype.contact.contact.update_contact'], 'validate': ['erpnext.setup.doctype.employee.employee.validate_employee_role'], 'on_update': ['erpnext.portal.utils.set_default_role']}, 'Communication': {'on_update': ['erpnext.support.doctype.service_level_agreement.service_level_agreement.on_communication_update', 'erpnext.support.doctype.issue.issue.set_first_response_time'], 'after_insert': ['erpnext.crm.utils.link_communications_with_prospect', 'erpnext.crm.utils.update_modified_timestamp']}, 'Address': {'validate': ['erpnext.regional.italy.utils.set_state_code']}, 'Email Unsubscribe': {'after_insert': ['erpnext.crm.doctype.email_campaign.email_campaign.unsubscribe_recipient']}, 'Integration Request': {'validate': ['erpnext.accounts.doctype.payment_request.payment_request.validate_payment']}}
    f = <function Document.run_method.<locals>.fn at 0x7fcb81fafe20>
    handler = 'erpnext.setup.doctype.transaction_deletion_record.transaction_deletion_record.check_for_running_deletion_job'
    hooks = [<function apply at 0x7fcb83482680>, <function check_for_running_deletion_job at 0x7fcb83483eb0>]
    kwargs = {}
    method = 'validate'
    self = <POSOpeningEntry: doctype=POS Opening Entry POS-OPE-2025-00002 docstatus=1>
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1504, in runner
    add_to_return_value(self, fn(self, *args, **kwargs))
    add_to_return_value = <function Document.hook.<locals>.add_to_return_value at 0x7fcb81fafbe0>
    args = ()
    fn = <function Document.run_method.<locals>.fn at 0x7fcb81fafe20>
    hooks = (<function apply at 0x7fcb83482680>, <function check_for_running_deletion_job at 0x7fcb83483eb0>)
    kwargs = {}
    method = 'validate'
    self = <POSOpeningEntry: doctype=POS Opening Entry POS-OPE-2025-00002 docstatus=1>
  File "/home/runner/frappe-bench/apps/frappe/frappe/model/document.py", line 1126, in fn
    return method_object(*args, **kwargs)
    args = ()
    kwargs = {}
    method = 'validate'
    method_object = <bound method POSOpeningEntry.validate of <POSOpeningEntry: doctype=POS Opening Entry POS-OPE-2025-00002 docstatus=1>>
    self = <POSOpeningEntry: doctype=POS Opening Entry POS-OPE-2025-00002 docstatus=1>
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/accounts/doctype/pos_opening_entry/pos_opening_entry.py", line 40, in validate
    self.check_open_pos_exists()
    self = <POSOpeningEntry: doctype=POS Opening Entry POS-OPE-2025-00002 docstatus=1>
  File "/home/runner/frappe-bench/apps/erpnext/erpnext/accounts/doctype/pos_opening_entry/pos_opening_entry.py", line 56, in check_open_pos_exists
    frappe.throw(
    self = <POSOpeningEntry: doctype=POS Opening Entry POS-OPE-2025-00002 docstatus=1>
  File "/home/runner/frappe-bench/apps/frappe/frappe/utils/messages.py", line 145, in throw
    msgprint(
    as_list = False
    exc = <class 'frappe.exceptions.ValidationError'>
    is_minimizable = False
    msg = '<strong>_Test POS Profile</strong> is open. Close the POS or cancel the existing POS Opening Entry to create a new POS Opening Entry.'
    primary_action = None
    title = 'POS Opening Entry Exists'
    wide = False
  File "/home/runner/frappe-bench/apps/frappe/frappe/utils/messages.py", line 106, in msgprint
    _raise_exception()
    _raise_exception = <function msgprint.<locals>._raise_exception at 0x7fcb81faf5b0>
    alert = False
    as_list = False
    as_table = False
    indicator = 'red'
    inspect = <module 'inspect' from '/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/inspect.py'>
    is_minimizable = False
    msg = '<strong>_Test POS Profile</strong> is open. Close the POS or cancel the existing POS Opening Entry to create a new POS Opening Entry.'
    out = {'message': '<strong>_Test POS Profile</strong> is open. Close the POS or cancel the existing POS Opening Entry to create a new POS Opening Entry.', 'title': 'POS Opening Entry Exists', 'indicator': 'red', 'raise_exception': 1, '__frappe_exc_id': 'c30be9812a4efc21f86655ba51d38f2525cda7710cdc92ba063eeb4b'}
    primary_action = None
    raise_exception = <class 'frappe.exceptions.ValidationError'>
    realtime = False
    title = 'POS Opening Entry Exists'
    wide = False
  File "/home/runner/frappe-bench/apps/frappe/frappe/utils/messages.py", line 57, in _raise_exception
    raise exc
    exc = ValidationError('<strong>_Test POS Profile</strong> is open. Close the POS or cancel the existing POS Opening Entry to create a new POS Opening Entry.')
    inspect = <module 'inspect' from '/opt/hostedtoolcache/Python/3.10.18/x64/lib/python3.10/inspect.py'>
    msg = '<strong>_Test POS Profile</strong> is open. Close the POS or cancel the existing POS Opening Entry to create a new POS Opening Entry.'
    out = {'message': '<strong>_Test POS Profile</strong> is open. Close the POS or cancel the existing POS Opening Entry to create a new POS Opening Entry.', 'title': 'POS Opening Entry Exists', 'indicator': 'red', 'raise_exception': 1, '__frappe_exc_id': 'c30be9812a4efc21f86655ba51d38f2525cda7710cdc92ba063eeb4b'}
    raise_exception = <class 'frappe.exceptions.ValidationError'>
frappe.exceptions.ValidationError: <strong>_Test POS Profile</strong> is open. Close the POS or cancel the existing POS Opening Entry to create a new POS Opening Entry.
```