### PR TITLE
fix: image condition

### DIFF
--- a/payments/overrides/payment_webform.py
+++ b/payments/overrides/payment_webform.py
@@ -87,7 +87,7 @@ def accept(web_form, data, docname=None, for_payment=False):
 		value = data.get(fieldname, None)
 
 		if df and df.fieldtype in ("Attach", "Attach Image"):
-			if value and "data:" and "base64" in value:
+			if value and "data:" in value and "base64" in value:
 				files.append((fieldname, value))
 				if not doc.name:
 					doc.set(fieldname, "")


### PR DESCRIPTION
This pull request addresses a bug in the file attachment validation logic within the `accept` function in `payments/overrides/payment_webform.py`. The change ensures that the code properly checks for both `"data:"` and `"base64"` in the value before processing file attachments.