### PR TITLE
fix(Web Form): extend instead of overriding

### DIFF
--- a/payments/hooks.py
+++ b/payments/hooks.py
@@ -92,9 +92,9 @@ before_uninstall = "payments.utils.delete_custom_fields"
 
 # DocType Class
 # ---------------
-# Override standard doctype classes
+# Extend standard doctype classes
 
-override_doctype_class = {"Web Form": "payments.overrides.payment_webform.PaymentWebForm"}
+extend_doctype_class = {"Web Form": "payments.overrides.payment_webform.PaymentWebForm"}
 
 # Document Events
 # ---------------


### PR DESCRIPTION
This pull request updates the way custom `DocType` classes are registered in the `payments/hooks.py` file. Instead of overriding the **Web Form** controller, we now extend it.

Depends on https://github.com/frappe/frappe/pull/33943
