### PR TITLE
fix(razorpay): add payment id validation to check relation with order id

### DIFF
--- a/payments/payment_gateways/doctype/razorpay_settings/razorpay_settings.py
+++ b/payments/payment_gateways/doctype/razorpay_settings/razorpay_settings.py
@@ -358,6 +358,8 @@ class RazorpaySettings(Document):
 					),
 					data=payment_options,
 				)
+				kwargs.update({"order_id": order.get("id")})
+				integration_request.update_status(kwargs, "Queued")
 				integration_request.db_set("output", get_json({"order": order}))
 				order["integration_request"] = integration_request.name
 				return order  # Order returned to be consumed by razorpay.js
@@ -392,7 +394,6 @@ class RazorpaySettings(Document):
 		until it is explicitly captured by merchant.
 		"""
 		data = json.loads(self.integration_request.data)
-		output = json.loads(self.integration_request.output or "{}")
 		settings = self.get_settings(data)
 
 		try:
@@ -401,7 +402,7 @@ class RazorpaySettings(Document):
 				auth=(settings.api_key, settings.api_secret),
 			)
 
-			if resp.get('order_id') != output.get("order", {}).get('id',""):
+			if resp.get('order_id') != data.get("order_id"):
 				frappe.throw(_("Order ID mismatch"))
 
 			if resp.get("status") == "authorized":

--- a/payments/payment_gateways/doctype/razorpay_settings/razorpay_settings.py
+++ b/payments/payment_gateways/doctype/razorpay_settings/razorpay_settings.py
@@ -74,7 +74,7 @@ from frappe.integrations.utils import (
 )
 from frappe.model.document import Document
 from frappe.utils import call_hook_method, cint, get_timestamp, get_url
-
+from frappe.integrations.utils import get_json
 from payments.utils import create_payment_gateway
 
 
@@ -358,6 +358,7 @@ class RazorpaySettings(Document):
 					),
 					data=payment_options,
 				)
+				integration_request.db_set("output", get_json({"order": order}))
 				order["integration_request"] = integration_request.name
 				return order  # Order returned to be consumed by razorpay.js
 			except Exception:
@@ -391,6 +392,7 @@ class RazorpaySettings(Document):
 		until it is explicitly captured by merchant.
 		"""
 		data = json.loads(self.integration_request.data)
+		output = json.loads(self.integration_request.output or "{}")
 		settings = self.get_settings(data)
 
 		try:
@@ -398,6 +400,9 @@ class RazorpaySettings(Document):
 				f"https://api.razorpay.com/v1/payments/{self.data.razorpay_payment_id}",
 				auth=(settings.api_key, settings.api_secret),
 			)
+
+			if resp.get('order_id') != output.get("order", {}).get('id',""):
+				frappe.throw(_("Order ID mismatch"))
 
 			if resp.get("status") == "authorized":
 				self.integration_request.update_status(data, "Authorized")


### PR DESCRIPTION
When `order_payment_success` was invoked using a previously successful payment ID and a new order ID, the transaction was incorrectly marked as successful.
This change introduces validation to prevent this unintended behavior.