### PR TITLE
chore: bump gocardless-pro

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "stripe~=10.12.0",
     "braintree~=4.20.0",
     "pycryptodome>=3.18.0,<4.0.0",
-    "gocardless-pro~=1.22.0",
+    "gocardless-pro~=3.2.0",
     "setuptools==80.9.0",
 ]
 


### PR DESCRIPTION
The GoCardless client library is over 5 years old now. Time to get current at 3.2.0:
https://pypi.org/project/gocardless-pro/#history