### PR TITLE
chore: bump gocardless

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -13,7 +13,7 @@ dependencies = [
     "stripe~=10.12.0",
     "braintree~=4.20.0",
     "pycryptodome>=3.18.0,<4.0.0",
-    "gocardless-pro~=1.22.0",
+    "gocardless-pro~=3.3.0",
     "setuptools==80.9.0",
 ]
 


### PR DESCRIPTION
gocardless 1.22.0 is over 5 years old, the current version as of 12/23/2025 is 3.3.0