### PR TITLE
feat: Payment Guard (Prevents Double Payment)

### DIFF
--- a/payments/templates/pages/stripe_checkout.py
+++ b/payments/templates/pages/stripe_checkout.py
@@ -5,6 +5,7 @@ import json
 import frappe
 from frappe import _
 from frappe.utils import cint, fmt_money
+from payments.utils import check_payment_status
 
 from payments.payment_gateways.doctype.stripe_settings.stripe_settings import (
 	get_gateway_controller,
@@ -34,7 +35,7 @@ def get_context(context):
 			context[key] = frappe.form_dict[key]
 
 		# Check if payment already completed
-		if frappe.utils.check_payment_status(
+		if check_payment_status(
 			context.reference_doctype,
 			context.reference_docname
 		):
@@ -45,6 +46,7 @@ def get_context(context):
 			)
 			frappe.local.flags.redirect_location = frappe.local.response.location
 			raise frappe.Redirect
+
 		gateway_controller = get_gateway_controller(
 			context.reference_doctype, context.reference_docname, context.payment_gateway
 		)
@@ -86,8 +88,8 @@ def get_header_image(doc, gateway_controller):
 def make_payment(stripe_token_id, data, reference_doctype=None, reference_docname=None, payment_gateway=None):
 	data = json.loads(data)
 
-	# Check if payment already completed
-	if frappe.utils.check_payment_status(reference_doctype, reference_docname):
+	# Check if payment already completed Redundancy Safeguard
+	if check_payment_status(reference_doctype, reference_docname):
 		frappe.throw(_('This payment has already been completed'))
 
 	data.update({"stripe_token_id": stripe_token_id})

--- a/payments/templates/pages/stripe_checkout.py
+++ b/payments/templates/pages/stripe_checkout.py
@@ -32,6 +32,19 @@ def get_context(context):
 	if not (set(expected_keys) - set(list(frappe.form_dict))):
 		for key in expected_keys:
 			context[key] = frappe.form_dict[key]
+
+		# Check if payment already completed
+		if frappe.utils.check_payment_status(
+			context.reference_doctype,
+			context.reference_docname
+		):
+			frappe.redirect_to_message(
+				_('Payment Completed'),
+				_('This payment request has already been processed'),
+				http_status_code=400
+			)
+			frappe.local.flags.redirect_location = frappe.local.response.location
+			raise frappe.Redirect
 		gateway_controller = get_gateway_controller(
 			context.reference_doctype, context.reference_docname, context.payment_gateway
 		)
@@ -72,6 +85,10 @@ def get_header_image(doc, gateway_controller):
 @frappe.whitelist(allow_guest=True)
 def make_payment(stripe_token_id, data, reference_doctype=None, reference_docname=None, payment_gateway=None):
 	data = json.loads(data)
+
+	# Check if payment already completed
+	if frappe.utils.check_payment_status(reference_doctype, reference_docname):
+		frappe.throw(_('This payment has already been completed'))
 
 	data.update({"stripe_token_id": stripe_token_id})
 

--- a/payments/utils/__init__.py
+++ b/payments/utils/__init__.py
@@ -3,6 +3,7 @@ from payments.utils.utils import (
 	create_payment_gateway,
 	delete_custom_fields,
 	erpnext_app_import_guard,
+ 	check_payment_status,
 	get_payment_gateway_controller,
 	make_custom_fields,
 )

--- a/payments/utils/utils.py
+++ b/payments/utils/utils.py
@@ -26,6 +26,17 @@ def get_payment_gateway_controller(payment_gateway):
 			frappe.throw(_("{0} Settings not found").format(payment_gateway))
 
 
+def check_payment_status(reference_doctype, reference_docname):
+    """Verify if payment request is already completed"""
+    try:
+        doc = frappe.get_doc(reference_doctype, reference_docname)
+        return doc.status in ['Paid']
+    except frappe.DoesNotExistError:
+        frappe.throw(_("Payment Request not found"))
+    except Exception as e:
+        frappe.log_error(_("Payment status check failed"), e)
+
+
 @frappe.whitelist(allow_guest=True, xss_safe=True)
 def get_checkout_url(**kwargs):
 	try:


### PR DESCRIPTION
# Prevent Double Payments

**What it does** – Stops users from paying twice. If a Payment Request is already marked *Paid*, the checkout page is skipped and a friendly message is shown.

**Why it matters** – No duplicate charges, better UX, and saves time.

**How it works** – On checkout, we check `check_payment_status(reference_doctype, reference_docname)`. If true, redirect to a "Payment already completed" page; otherwise, proceed.

**Next steps** – Should we add the same check to other gateways (Braintree, Paytm, etc.)? Let me know!



https://github.com/user-attachments/assets/c4c8b9fa-8bc9-4fa3-8ecc-79aeea47eb3c