### PR TITLE
fix(stripe): improve mobile card input and error style

### DIFF
--- a/payments/templates/pages/stripe_checkout.css
+++ b/payments/templates/pages/stripe_checkout.css
@@ -109,9 +109,34 @@
   padding: 10rem;
 }
 
+#card-errors {
+  clear: both;
+  color: #fa755a;
+}
+
 @media (max-width: 48rem) {
   #payment-section {
     padding: 0rem;
     min-height: 70vh;
-  },
+  }
+
+  .stripe label {
+    height: auto;
+    line-height: normal;
+    display: flex;
+    flex-direction: column;
+  }
+
+  .stripe label > span {
+    width: 100%;
+    margin-bottom: 6px;
+  }
+
+   .field {
+    width: 100%;
+  }
+
+  #card-errors {
+    margin-top: 6px;
+  }
 }


### PR DESCRIPTION
## Summary
- Improve mobile styling for credit card input
- Improve error style

## Changes
| View | Before | After |
|----|----|----|
| Desktop | <img width="1391" height="695" alt="Screenshot 2026-03-13 at 3 45 31 PM" src="https://github.com/user-attachments/assets/dcafe060-8245-48c6-bc22-77d37911f369" /> | <img width="1391" height="696" alt="Screenshot 2026-03-13 at 3 35 35 PM" src="https://github.com/user-attachments/assets/2e172990-69f3-432b-9c72-d45f483a3871" /> |
| Mobile | <img width="374" height="628" alt="Screenshot 2026-03-13 at 3 46 18 PM" src="https://github.com/user-attachments/assets/57d44574-b455-464f-bd21-5dcbdb8fe4c2" /> | <img width="377" height="628" alt="Screenshot 2026-03-13 at 3 36 04 PM" src="https://github.com/user-attachments/assets/5a4530df-7469-4539-9118-efb4f5919afe" /> |
