### PR TITLE
build: upgrade to frappe v16 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,7 +34,7 @@ jobs:
 
     services:
       mysql:
-        image: mariadb:10.6
+        image: mariadb:11.8
         env:
           MARIADB_ROOT_PASSWORD: 'root'
         ports:
@@ -43,12 +43,12 @@ jobs:
 
     steps:
       - name: Clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Setup Python
-        uses: actions/setup-python@v5
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
+          python-version: '3.14'
 
       - name: Check for valid Python & Merge Conflicts
         run: |
@@ -59,9 +59,9 @@ jobs:
           fi
 
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
-          node-version: 18
+          node-version: 24
           check-latest: true
 
       - name: Add to Hosts
@@ -127,7 +127,7 @@ jobs:
     if: ${{ github.event_name != 'pull_request' }}
     steps:
       - name: Clone
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Download artifacts
         uses: actions/download-artifact@v4

--- a/.github/workflows/linter.yml
+++ b/.github/workflows/linter.yml
@@ -1,10 +1,7 @@
 name: Linter
 
 on:
-  pull_request:
-  workflow_dispatch:
-  push:
-    branches: [ develop ]
+  pull_request: { }
 
 permissions:
   contents: read
@@ -20,12 +17,12 @@ jobs:
     if: github.event_name == 'pull_request'
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 200
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: 16
+          node-version: 24
           check-latest: true
 
       - name: Check commit titles
@@ -39,16 +36,21 @@ jobs:
     if: github.event_name == 'pull_request'
 
     steps:
-      - uses: actions/checkout@v4
-      - uses: actions/setup-python@v5
+      - uses: actions/checkout@v6
+
+      - name: Set up Python 3.14
+        uses: actions/setup-python@v6
         with:
-          python-version: '3.10'
-      - uses: pre-commit/action@v3.0.0
+          python-version: '3.14'
+      
+      - name: Install and Run Pre-commit
+        uses: pre-commit/action@v3.0.0
 
       - name: Download Semgrep rules
         run: git clone --depth 1 https://github.com/frappe/semgrep-rules.git frappe-semgrep-rules
 
+      - name: Download semgrep
+        run: pip install semgrep
+
       - name: Run Semgrep rules
-        run: |
-          pip install semgrep==1.90.0
-          semgrep ci --config ./frappe-semgrep-rules/rules --config r/python.lang.correctness
+        run: semgrep ci --config ./frappe-semgrep-rules/rules --config r/python.lang.correctness

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,23 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 0.5%
+
+    patch:
+      default:
+        target: 85%
+        threshold: 0%
+        base: auto
+        branches:
+          - develop
+        if_ci_failed: ignore
+        only_pulls: true
+
+comment:
+  layout: "diff, files"
+  require_changes: true

--- a/payments/hooks.py
+++ b/payments/hooks.py
@@ -120,8 +120,6 @@ scheduler_events = {
 # Testing
 # -------
 
-before_tests = "erpnext.setup.utils.before_tests"  # To setup company and accounts
-
 # Overriding Methods
 # ------------------------------
 #

--- a/payments/payment_gateways/doctype/mpesa_settings/test_mpesa_settings.py
+++ b/payments/payment_gateways/doctype/mpesa_settings/test_mpesa_settings.py
@@ -1,7 +1,6 @@
 # Copyright (c) 2020, Frappe Technologies Pvt. Ltd. and Contributors
 # See license.txt
 
-import unittest
 from json import dumps
 
 import frappe
@@ -10,6 +9,7 @@ from erpnext.accounts.doctype.pos_invoice.test_pos_invoice import create_pos_inv
 from erpnext.accounts.doctype.pos_opening_entry.test_pos_opening_entry import create_opening_entry
 from erpnext.accounts.doctype.pos_profile.test_pos_profile import make_pos_profile
 from erpnext.stock.doctype.item.test_item import make_item
+from erpnext.tests.utils import ERPNextTestSuite
 
 from payments.payment_gateways.doctype.mpesa_settings.mpesa_settings import (
 	create_mode_of_payment,
@@ -18,7 +18,11 @@ from payments.payment_gateways.doctype.mpesa_settings.mpesa_settings import (
 )
 
 
-class TestMpesaSettings(unittest.TestCase):
+class TestMpesaSettings(ERPNextTestSuite):
+	@ERPNextTestSuite.change_settings(
+		"Global Defaults",
+		{"default_company": "Wind Power LLC"},
+	)
 	def setUp(self):
 		# create payment gateway in setup
 		create_mpesa_settings(payment_gateway_name="_Test")

--- a/payments/utils/utils.py
+++ b/payments/utils/utils.py
@@ -61,7 +61,7 @@ def create_payment_gateway(gateway, settings=None, controller=None):
 
 def make_custom_fields():
 	if not frappe.get_meta("Web Form").has_field("payments_tab"):
-		click.secho("* Installing Payment Custom Fields in Web Form")
+		click.secho("* Installing Payment Custom Fields")
 
 		create_custom_fields(
 			{

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ authors = [
     { name = "Frappe Technologies Pvt Ltd", email = "hello@frappe.io"}
 ]
 description = "Payments app for frappe"
-requires-python = ">=3.10"
+requires-python = ">=3.14"
 readme = "README.md"
 dynamic = ["version"]
 dependencies = [
@@ -61,3 +61,7 @@ docstring-code-format = true
 [project.urls]
 Repository = "https://github.com/frappe/payments.git"
 "Bug Reports" = "https://github.com/frappe/payments/issues"
+
+[tool.bench.frappe-dependencies]
+frappe = ">=16.0.0,<17.0.0"
+erpnext = ">=16.0.0,<17.0.0"


### PR DESCRIPTION
- [x] Bump required Python version to 3.14
- [x] Pin Frappe and ERPNext dependency to >=16.0.0,<17.0.0
- [x] Update CI to use Python 3.14, Node 24, and MariaDB 11.8
- [x] Add codecov.yml for coverage reporting
- [x] Fix failing tests caused by ERPNext test suite refactor