### PR TITLE
fix: pass order_id and store transaction ID in Braintree integration

### DIFF
--- a/payments/payment_gateways/doctype/braintree_settings/braintree_settings.py
+++ b/payments/payment_gateways/doctype/braintree_settings/braintree_settings.py
@@ -217,6 +217,7 @@ class BraintreeSettings(Document):
 			{
 				"amount": self.data.amount,
 				"payment_method_nonce": self.data.payload_nonce,
+				"order_id": self.data.order_id,  # already in self.data, just not passed
 				"options": {"submit_for_settlement": True},
 			}
 		)


### PR DESCRIPTION
## Description

The Braintree integration in `braintree_settings.py` omits two critical fields when processing transactions:

1. **`order_id` is never sent to Braintree** despite being available in `self.data`. The Braintree Transaction Sale API accepts `order_id` as a standard field (see [[Braintree Transaction API](https://developer.paypal.com/braintree/docs/reference/request/transaction/sale)](https://developer.paypal.com/braintree/docs/reference/request/transaction/sale)), allowing merchants to store a reference identifier against each transaction visible in the Braintree merchant dashboard and searchable via the API. Without this, there is no way to trace a Braintree transaction back to the originating ERPNext Payment Request from the Braintree side.

2. **The Braintree transaction ID is never persisted in ERPNext.** On success, `result.transaction.id` is discarded and only `result.transaction.status` is stored in the Integration Request `output` field. This makes it impossible to cross-reference an ERPNext Integration Request with a Braintree transaction.

### Changes

- Pass `self.data.order_id` (the Payment Request name) as `order_id` in the `braintree.Transaction.sale()` call
- Store `result.transaction.id` instead of `result.transaction.status` in the Integration Request `output` field on success

### Before

```python
result = braintree.Transaction.sale(
    {
        "amount": self.data.amount,
        "payment_method_nonce": self.data.payload_nonce,
        "options": {"submit_for_settlement": True},
    }
)
# ...
self.integration_request.db_set("output", result.transaction.status, update_modified=False)
```

### After

```python
result = braintree.Transaction.sale(
    {
        "amount": self.data.amount,
        "payment_method_nonce": self.data.payload_nonce,
        "order_id": self.data.order_id,
        "options": {"submit_for_settlement": True},
    }
)
# ...
self.integration_request.db_set("output", result.transaction.id, update_modified=False)
```

---

## Test Scenario

### Enable Approver / Reviewer Steps

1. Configure a Braintree sandbox account with valid credentials in **Braintree Settings**
2. Create a Sales Invoice and generate a **Payment Request** from it (e.g. `PAY-REQ-2024-00001`)
3. Open the payment link and complete a test transaction using Braintree's sandbox card `4111111111111111`
4. In your Braintree sandbox merchant dashboard, navigate to **Transactions** and open the completed transaction
5. Verify that the **Order ID** field shows `PAY-REQ-2024-00001` — matching the Payment Request name in ERPNext
6. In ERPNext, open the **Integration Request** log created for this transaction
7. Verify that the **Output** field contains the Braintree transaction ID (e.g. `7kg3qt`) rather than a status string like `submitted_for_settlement`
8. Cross-reference: search for the transaction in Braintree by Order ID and confirm it returns the correct transaction

### Reference
- [Braintree Transaction Sale API — `order_id` field](https://developer.paypal.com/braintree/docs/reference/request/transaction/sale) — max 255 characters, 127 for PayPal transactions
- [Braintree Transaction Search — `order_id` as searchable field](https://developer.paypal.com/braintree/docs/reference/request/transaction/search/php)