### PR TITLE
fix(stripe): correct payment success redirect url

### DIFF
--- a/payments/payment_gateways/doctype/stripe_settings/stripe_settings.py
+++ b/payments/payment_gateways/doctype/stripe_settings/stripe_settings.py
@@ -275,10 +275,8 @@ class StripeSettings(Document):
 		else:
 			redirect_url = "payment-failed"
 
-		if redirect_to and "?" in redirect_url:
-			redirect_url += "&" + urlencode({"redirect_to": redirect_to})
-		else:
-			redirect_url += "?" + urlencode({"redirect_to": redirect_to})
+		if redirect_to:
+			redirect_url += ("&" if "?" in redirect_url else "?") + urlencode({"redirect_to": redirect_to})
 
 		if redirect_message:
 			redirect_url += "&" + urlencode({"redirect_message": redirect_message})


### PR DESCRIPTION
Issue: 

Stripe payment success redirect url is built incorrectly when redirect_to is empty. The flow appends redirect_to=None to the success url, which can break the page or lead to an invalid follow-up redirect. This change updates the redirect logic to append redirect_to only when it has a real value, preserving a valid success url.

Ref: [#68040](https://support.frappe.io/helpdesk/tickets/68040)