### PR TITLE
fix(gocardless): make mandate reuse work under a Customer naming series

### DIFF
--- a/payments/payment_gateways/doctype/gocardless_mandate/test_gocardless_mandate.py
+++ b/payments/payment_gateways/doctype/gocardless_mandate/test_gocardless_mandate.py
@@ -1,8 +1,77 @@
 # Copyright (c) 2018, Frappe Technologies and Contributors
 # See license.txt
 
-import unittest
+import frappe
+from frappe.tests.utils import FrappeTestCase
+
+from payments.templates.pages.gocardless_confirmation import create_mandate
 
 
-class TestGoCardlessMandate(unittest.TestCase):
-	pass
+def _make_payment_request(customer_name):
+	"""A Customer -> Sales Invoice -> Payment Request chain, as the GoCardless
+	confirmation flow expects, so create_mandate() can resolve the reference."""
+	customer = frappe.get_doc({"doctype": "Customer", "customer_name": customer_name}).insert(
+		ignore_permissions=True
+	)
+	si = frappe.get_doc(
+		{
+			"doctype": "Sales Invoice",
+			"company": "_Test Company",
+			"customer": customer.name,
+			"currency": "INR",
+			"items": [{"item_code": "Consulting", "qty": 1, "rate": 100}],
+		}
+	)
+	si.flags.ignore_mandatory = True
+	si.insert(ignore_permissions=True)
+	pr = frappe.get_doc(
+		{
+			"doctype": "Payment Request",
+			"payment_request_type": "Inward",
+			"reference_doctype": "Sales Invoice",
+			"reference_name": si.name,
+			"party_type": "Customer",
+			"party": customer.name,
+			"grand_total": 100,
+			"currency": "INR",
+			"email_to": "x@example.com",
+		}
+	)
+	pr.flags.ignore_mandatory = True
+	pr.flags.ignore_validate = True
+	pr.insert(ignore_permissions=True)
+	return customer, pr
+
+
+class TestGoCardlessMandate(FrappeTestCase):
+	def test_failed_mandate_creation_logs_transaction_context(self):
+		"""When create_mandate() can't persist a mandate, the Error Log entry must
+		spell out the transaction (reference doc, customer, mandate id) in a readable
+		summary so the failure is actionable on its own -- the bare traceback Frappe
+		captures by default buries those values in a locals dump (#89 diagnosis)."""
+		customer, pr = _make_payment_request("_Test GC Diag Customer")
+
+		# Force a failure inside create_mandate's insert: gocardless_customer is reqd,
+		# so an empty value raises MandatoryError, which create_mandate swallows.
+		create_mandate(
+			{
+				"mandate": "MD-DIAG-1",
+				"customer": "",
+				"reference_doctype": "Payment Request",
+				"reference_docname": pr.name,
+			}
+		)
+		self.assertFalse(frappe.db.exists("GoCardless Mandate", "MD-DIAG-1"))
+
+		log = frappe.get_all(
+			"Error Log",
+			filters={"method": ("like", "%nable to create mandate%")},
+			fields=["error"],
+			order_by="creation desc",
+			limit=1,
+		)
+		self.assertTrue(log, "expected an Error Log entry for the failed mandate creation")
+		error = log[0]["error"]
+		# The readable summary line the enrichment adds (distinct from a locals dump).
+		self.assertIn(f"Could not save GoCardless Mandate MD-DIAG-1 for Payment Request {pr.name}", error)
+		self.assertIn(f"customer: {customer.customer_name}", error)

--- a/payments/payment_gateways/doctype/gocardless_mandate/test_gocardless_mandate.py
+++ b/payments/payment_gateways/doctype/gocardless_mandate/test_gocardless_mandate.py
@@ -7,12 +7,16 @@ from frappe.tests.utils import FrappeTestCase
 from payments.templates.pages.gocardless_confirmation import create_mandate
 
 
-def _make_payment_request(customer_name):
+def _make_payment_request(customer_name, naming_series=None):
 	"""A Customer -> Sales Invoice -> Payment Request chain, as the GoCardless
-	confirmation flow expects, so create_mandate() can resolve the reference."""
-	customer = frappe.get_doc({"doctype": "Customer", "customer_name": customer_name}).insert(
-		ignore_permissions=True
-	)
+	confirmation flow expects, so create_mandate() can resolve the reference.
+
+	Pass naming_series to mint a Customer whose docname differs from its display
+	name (the Customer-naming-series case behind #89)."""
+	customer_doc = {"doctype": "Customer", "customer_name": customer_name}
+	if naming_series:
+		customer_doc["naming_series"] = naming_series
+	customer = frappe.get_doc(customer_doc).insert(ignore_permissions=True)
 	si = frappe.get_doc(
 		{
 			"doctype": "Sales Invoice",
@@ -43,7 +47,43 @@ def _make_payment_request(customer_name):
 	return customer, pr
 
 
+def _use_customer_naming_series(test):
+	"""Switch Customer autonaming to a series so docname != customer_name, and
+	restore the original setting after the test."""
+	original = frappe.db.get_default("cust_master_name")
+	frappe.db.set_default("cust_master_name", "Naming Series")
+	frappe.clear_cache()
+
+	def restore():
+		frappe.db.set_default("cust_master_name", original or "")
+		frappe.clear_cache()
+
+	test.addCleanup(restore)
+
+
 class TestGoCardlessMandate(FrappeTestCase):
+	def test_create_mandate_persists_keyed_by_customer_docname(self):
+		"""Under a Customer naming series, create_mandate() must store the Customer
+		*docname* in the Link -> Customer field. Storing customer_name (display) fails
+		validation, the insert is silently swallowed, and reuse breaks (#89)."""
+		_use_customer_naming_series(self)
+		customer, pr = _make_payment_request("Reuse89 Series Co", naming_series="CUST-.YYYY.-")
+		self.assertNotEqual(customer.name, customer.customer_name)  # precondition
+
+		create_mandate(
+			{
+				"mandate": "MD-NS-1",
+				"customer": "CU-NS-1",
+				"reference_doctype": "Payment Request",
+				"reference_docname": pr.name,
+			}
+		)
+
+		# Persisted, and keyed by the Customer docname...
+		self.assertEqual(frappe.db.get_value("GoCardless Mandate", "MD-NS-1", "customer"), customer.name)
+		# ...so it is found by the exact filter check_mandate_validity() uses.
+		self.assertTrue(frappe.db.exists("GoCardless Mandate", {"customer": customer.name, "disabled": 0}))
+
 	def test_failed_mandate_creation_logs_transaction_context(self):
 		"""When create_mandate() can't persist a mandate, the Error Log entry must
 		spell out the transaction (reference doc, customer, mandate id) in a readable

--- a/payments/payment_gateways/doctype/gocardless_settings/gocardless_settings.py
+++ b/payments/payment_gateways/doctype/gocardless_settings/gocardless_settings.py
@@ -37,7 +37,10 @@ class GoCardlessSettings(Document):
 	def on_payment_request_submission(self, data):
 		if data.reference_doctype != "Fees":
 			customer_data = frappe.db.get_value(
-				data.reference_doctype, data.reference_name, ["company", "customer_name"], as_dict=1
+				data.reference_doctype,
+				data.reference_name,
+				["company", "customer", "customer_name"],
+				as_dict=1,
 			)
 
 		data = {
@@ -48,6 +51,9 @@ class GoCardlessSettings(Document):
 			"reference_docname": data.name,
 			"payer_email": data.email_to or frappe.session.user,
 			"payer_name": customer_data.customer_name,
+			# Mandates are keyed by the Customer docname (the Link target), not the
+			# display name, so reuse works under a Customer naming series (#89).
+			"customer": customer_data.customer,
 			"order_id": data.name,
 			"currency": data.currency,
 			"charge_date": data.transaction_date or frappe.utils.nowdate(),
@@ -62,23 +68,28 @@ class GoCardlessSettings(Document):
 		else:
 			return True
 
-	def check_mandate_validity(self, data):
-		if frappe.db.exists("GoCardless Mandate", dict(customer=data.get("payer_name"), disabled=0)):
-			registered_mandate = frappe.db.get_value(
-				"GoCardless Mandate", dict(customer=data.get("payer_name"), disabled=0), "mandate"
-			)
-			self.initialize_client()
-			mandate = self.client.mandates.get(registered_mandate)
+	def get_registered_mandate(self, customer):
+		"""Return the stored GoCardless mandate id for an ERPNext Customer (by docname),
+		or None if the customer has no active registered mandate."""
+		if not customer:
+			return None
+		return frappe.db.get_value("GoCardless Mandate", dict(customer=customer, disabled=0), "mandate")
 
-			if (
-				mandate.status == "pending_customer_approval"
-				or mandate.status == "pending_submission"
-				or mandate.status == "submitted"
-				or mandate.status == "active"
-			):
-				return {"mandate": registered_mandate}, mandate.next_possible_charge_date
-			else:
-				return None, None
+	def check_mandate_validity(self, data):
+		registered_mandate = self.get_registered_mandate(data.get("customer"))
+		if not registered_mandate:
+			return None, None
+
+		self.initialize_client()
+		mandate = self.client.mandates.get(registered_mandate)
+
+		if (
+			mandate.status == "pending_customer_approval"
+			or mandate.status == "pending_submission"
+			or mandate.status == "submitted"
+			or mandate.status == "active"
+		):
+			return {"mandate": registered_mandate}, mandate.next_possible_charge_date
 		else:
 			return None, None
 

--- a/payments/payment_gateways/doctype/gocardless_settings/test_gocardless_settings.py
+++ b/payments/payment_gateways/doctype/gocardless_settings/test_gocardless_settings.py
@@ -1,8 +1,40 @@
 # Copyright (c) 2018, Frappe Technologies and Contributors
 # See license.txt
 
-import unittest
+import frappe
+from frappe.tests.utils import FrappeTestCase
 
 
-class TestGoCardlessSettings(unittest.TestCase):
-	pass
+class TestGoCardlessSettings(FrappeTestCase):
+	def _use_customer_naming_series(self):
+		original = frappe.db.get_default("cust_master_name")
+		frappe.db.set_default("cust_master_name", "Naming Series")
+		frappe.clear_cache()
+		self.addCleanup(
+			lambda: (frappe.db.set_default("cust_master_name", original or ""), frappe.clear_cache())
+		)
+
+	def test_get_registered_mandate_keys_on_customer_docname(self):
+		"""A stored mandate must be retrievable by the ERPNext Customer *docname*.
+		Keying on customer_name (display) misses the record under a Customer naming
+		series, so reuse falls through and the payer is re-prompted (#89)."""
+		self._use_customer_naming_series()
+		customer = frappe.get_doc(
+			{"doctype": "Customer", "customer_name": "Reg Mandate Co", "naming_series": "CUST-.YYYY.-"}
+		).insert(ignore_permissions=True)
+		self.assertNotEqual(customer.name, customer.customer_name)  # precondition
+		frappe.get_doc(
+			{
+				"doctype": "GoCardless Mandate",
+				"mandate": "MD-REG-1",
+				"customer": customer.name,
+				"gocardless_customer": "CU-REG-1",
+			}
+		).insert(ignore_permissions=True)
+
+		settings = frappe.new_doc("GoCardless Settings")
+		# Found by docname...
+		self.assertEqual(settings.get_registered_mandate(customer.name), "MD-REG-1")
+		# ...not by the display name, and tolerant of a missing/empty customer.
+		self.assertIsNone(settings.get_registered_mandate(customer.customer_name))
+		self.assertIsNone(settings.get_registered_mandate(None))

--- a/payments/payment_gateways/doctype/gocardless_settings/test_gocardless_settings.py
+++ b/payments/payment_gateways/doctype/gocardless_settings/test_gocardless_settings.py
@@ -38,3 +38,19 @@ class TestGoCardlessSettings(FrappeTestCase):
 		# ...not by the display name, and tolerant of a missing/empty customer.
 		self.assertIsNone(settings.get_registered_mandate(customer.customer_name))
 		self.assertIsNone(settings.get_registered_mandate(None))
+
+	def test_checkout_resolves_payer_from_display_name(self):
+		"""The checkout URL carries the Customer display name (Payment Request sends
+		customer_name as payer_name), so resolving the payer must tolerate
+		docname != customer_name under a Customer naming series, otherwise the very
+		first subscription dies before a mandate can be created (#89)."""
+		from payments.templates.pages.gocardless_checkout import get_payer_customer
+
+		self._use_customer_naming_series()
+		customer = frappe.get_doc(
+			{"doctype": "Customer", "customer_name": "Checkout Payer Co", "naming_series": "CUST-.YYYY.-"}
+		).insert(ignore_permissions=True)
+		self.assertNotEqual(customer.name, customer.customer_name)  # precondition
+
+		resolved = get_payer_customer(customer.customer_name)
+		self.assertEqual(resolved.name, customer.name)

--- a/payments/templates/pages/gocardless_checkout.py
+++ b/payments/templates/pages/gocardless_checkout.py
@@ -55,7 +55,7 @@ def check_mandate(data, reference_doctype, reference_docname):
 
 	client = gocardless_initialization(reference_docname)
 
-	payer = frappe.get_doc("Customer", data["payer_name"])
+	payer = get_payer_customer(data["payer_name"])
 
 	if payer.customer_type == "Individual" and payer.customer_primary_contact is not None:
 		primary_contact = frappe.get_doc("Contact", payer.customer_primary_contact)
@@ -96,3 +96,15 @@ def check_mandate(data, reference_doctype, reference_docname):
 	except Exception:
 		frappe.log_error("GoCardless Payment Error")
 		return {"redirect_to": "payment-failed"}
+
+
+def get_payer_customer(payer_name):
+	"""Resolve the paying Customer from the value the checkout URL carries.
+
+	Payment Request builds the URL with payer_name = customer_name (the display
+	name), which under a Customer naming series is not the Customer docname. Look
+	the Customer up by docname first, then fall back to customer_name (#89)."""
+	if frappe.db.exists("Customer", payer_name):
+		return frappe.get_doc("Customer", payer_name)
+	docname = frappe.db.get_value("Customer", {"customer_name": payer_name}, "name")
+	return frappe.get_doc("Customer", docname or payer_name)

--- a/payments/templates/pages/gocardless_confirmation.py
+++ b/payments/templates/pages/gocardless_confirmation.py
@@ -102,4 +102,16 @@ def create_mandate(data):
 			).insert(ignore_permissions=True)
 
 		except Exception:
-			frappe.log_error("Gocardless: Unable to create mandate")
+			# Persisting the mandate is what lets future payments reuse it instead of
+			# re-prompting the payer (#89). Summarise which transaction/customer failed
+			# so the Error Log entry is actionable on its own, above the traceback.
+			frappe.log_error(
+				title="GoCardless: Unable to create mandate",
+				message=(
+					f"Could not save GoCardless Mandate {mandate} for "
+					f"{data.get('reference_doctype')} {data.get('reference_docname')} "
+					f"(customer: {erpnext_customer.customer_name if erpnext_customer else None}, "
+					f"gocardless_customer: {data.get('customer')}).\n\n"
+					f"{frappe.get_traceback(with_context=True)}"
+				),
+			)

--- a/payments/templates/pages/gocardless_confirmation.py
+++ b/payments/templates/pages/gocardless_confirmation.py
@@ -88,15 +88,21 @@ def create_mandate(data):
 			as_dict=1,
 		)
 		erpnext_customer = frappe.db.get_value(
-			reference_doc.reference_doctype, reference_doc.reference_name, ["customer_name"], as_dict=1
+			reference_doc.reference_doctype,
+			reference_doc.reference_name,
+			["customer", "customer_name"],
+			as_dict=1,
 		)
 
 		try:
 			frappe.get_doc(
 				{
 					"doctype": "GoCardless Mandate",
+					# `customer` is a Link -> Customer field, so it must hold the Customer
+					# docname, not the display name: under a Customer naming series the two
+					# differ and storing customer_name fails validation (#89).
 					"mandate": mandate,
-					"customer": erpnext_customer.customer_name,
+					"customer": erpnext_customer.customer,
 					"gocardless_customer": data.get("customer"),
 				}
 			).insert(ignore_permissions=True)


### PR DESCRIPTION
## Why

`GoCardless Mandate.customer` is a `Link -> Customer` custom field, so it must
hold the Customer **docname**. Two code paths instead used the Customer display
name (`customer_name`):

- `gocardless_confirmation.create_mandate()` stored `customer_name` in the
  mandate's `customer` field, and `GoCardlessSettings.check_mandate_validity()`
  looked the mandate up by the same display value.
- `gocardless_checkout.check_mandate()` resolved the payer with
  `get_doc("Customer", payer_name)`, where `payer_name` is the `customer_name`
  that Payment Request puts in the checkout URL.

On sites where the Customer naming rule is "Customer Name", the docname equals
`customer_name`, so this works by coincidence. On sites using a Customer naming
series, the docname differs from `customer_name`, and:

- the mandate insert fails `LinkValidationError` and is silently swallowed, so
  no mandate row is stored;
- even with a row present, the reuse lookup keys on the wrong value;
- the checkout payer lookup raises `DoesNotExistError`.

Because the first charge goes through the redirect-flow mandate id directly, the
first payment still succeeds; the breakage only surfaces on the next payment as
a repeated mandate prompt, which is the behaviour reported in
frappe/payments#89.

## What

- Store and look the mandate up by the Customer docname, carried through as
  `data["customer"]`.
- Extract `GoCardlessSettings.get_registered_mandate()` for the lookup, which
  also collapses the previous `exists()` + `get_value()` double query.
- Extract `gocardless_checkout.get_payer_customer()`, which resolves the payer
  by docname and falls back to `customer_name`, so the redirect flow is created
  regardless of the Customer naming rule.

Verified end-to-end against the GoCardless sandbox API under a Customer naming
series: the mandate is now persisted and reused on the second payment. Tests
cover the mandate keying, the lookup helper, and the payer resolution.

This resolves frappe/payments#89 for sites using a Customer naming series. Sites
named by customer_name were already unaffected.

## Note

Builds on #231 (its diagnostic logging commit is included here as the base of
this branch) and should be merged after it; once #231 lands, this PR's diff
reduces to the two fix commits.

Refs frappe/payments#89
