### PR TITLE
fix: create razorpay order when order_id is not a razorpay id (backport #230)

### DIFF
--- a/payments/payment_gateways/doctype/razorpay_settings/razorpay_settings.py
+++ b/payments/payment_gateways/doctype/razorpay_settings/razorpay_settings.py
@@ -325,7 +325,9 @@ class RazorpaySettings(Document):
 		return kwargs
 
 	def get_payment_url(self, **kwargs):
-		if not kwargs.get("order_id"):
+		# create a razorpay order unless a valid razorpay order id is already provided
+		if not str(kwargs.get("order_id") or "").startswith("order_"):
+			kwargs.setdefault("receipt", kwargs.get("order_id"))
 			order = self.create_order(**kwargs)
 			kwargs.update({"order_id": order.get("id")})
 


### PR DESCRIPTION
Issue: Razorpay Checkout fails with a 400 error when paying  system passes the Payment Request name (e.g. `ACC-PRQ-2026-00003`) as `order_id`, which is not a valid Razorpay order id. `get_payment_url` only created a Razorpay order when `order_id` was empty, so for the Payment Request flow no real order was ever created. After the checkout template started sending `order_id` as a top-level option, Razorpay validates it against the Orders API and rejects the invalid id, returning a 400 and breaking checkout.

This creates a real order via the Orders API whenever the provided value is not a Razorpay order id (`order_...`), keeping the caller's original reference as the order receipt.

Ref: [#70591](https://support.frappe.io/helpdesk/tickets/70591)