### PR TITLE
Convert raw SQL to db-agnostic calls

### DIFF
--- a/payments/payment_gateways/doctype/mpesa_settings/test_mpesa_settings.py
+++ b/payments/payment_gateways/doctype/mpesa_settings/test_mpesa_settings.py
@@ -48,8 +48,8 @@ class TestMpesaSettings(PaymentsTestSuite):
 		super().tearDown()
 		for x in frappe.db.get_all("POS Opening Entry"):
 			frappe.get_doc("POS Opening Entry", x.name).cancel().delete()
-		frappe.db.sql("delete from `tabMpesa Settings`")
-		frappe.db.sql("delete from `tabIntegration Request` where integration_request_service = 'Mpesa'")
+		frappe.db.delete("Mpesa Settings")
+		frappe.db.delete("Integration Request", {"integration_request_service": "Mpesa"})
 
 	def test_creation_of_payment_gateway(self, mock_stk_push, mock_get_account_balance):
 		mode_of_payment = create_mode_of_payment("Mpesa-_Test", payment_type="Phone")


### PR DESCRIPTION
Hi! I'm a member of the [AgriTheory team](https://github.com/agritheory/), which maintains a number of Frappe and ERPNext apps. We're in the process of migrating them to version-16, and part of that process is updating any SQL queries in the code to support PostgreSQL in addition to MariaDB. As some of our apps use other Frappe apps as a dependency, we figured we'd help in the effort here.

This PR converts the remaining `frappe.db.sql` calls with MariaDB-specific syntax (backtick-quoted table names) into database-agnostic `frappe.db.delete()` calls.

We scanned the full codebase — source, tests, and patches — with an internal SQL registry tool. `payments` only had two such calls, both in `tearDown()` of `test_mpesa_settings.py`; no other changes were needed in the codebase or in patches. We also checked for other common MariaDB-only patterns (`SHOW`/`DESCRIBE`, `GROUP_CONCAT`, `LIMIT x,y`, raw aggregate strings in `get_all()`) and found none.

All 5 existing tests in the app pass unchanged after this refactor.
